### PR TITLE
on datepicker init, switch month view to the active date...

### DIFF
--- a/src/datepicker.coffee
+++ b/src/datepicker.coffee
@@ -10,7 +10,7 @@ module.exports = class Datepicker extends ViewHelpers
   init: (model) ->
     @lang = model.get("lang") || "en"
     @builders = new Builders(@lang, moment)
-    currentDate = moment()
+    currentDate = model.get("active") || moment()
     @gotoMonthView currentDate
   
   create: (model, dom) ->


### PR DESCRIPTION
…rather than to today.
If the datepicker has a value already, it ought to be focused on that date when it first appears. This is useful when the default date is not today, but some other date.
